### PR TITLE
Fix infinite blocking in VddIoControl in case of a driver crash

### DIFF
--- a/core/parsec-vdd.h
+++ b/core/parsec-vdd.h
@@ -279,10 +279,14 @@ static DWORD VddIoControl(HANDLE vdd, VddCtlCode code, const void *data, size_t 
     if (data != NULL && size > 0)
         memcpy(InBuffer, data, (size < sizeof(InBuffer)) ? size : sizeof(InBuffer));
 
-    Overlapped.hEvent = CreateEventA(NULL, FALSE, FALSE, NULL);
+    Overlapped.hEvent = CreateEventA(NULL, TRUE, FALSE, NULL);
     DeviceIoControl(vdd, (DWORD)code, InBuffer, sizeof(InBuffer), &OutBuffer, sizeof(DWORD), NULL, &Overlapped);
 
-    GetOverlappedResult(vdd, &Overlapped, &NumberOfBytesTransferred, TRUE);
+    if (!GetOverlappedResultEx(vdd, &Overlapped, &NumberOfBytesTransferred, 5000, FALSE))
+    {
+        CloseHandle(Overlapped.hEvent);
+        return 0;
+    }
 
     if (Overlapped.hEvent != NULL)
         CloseHandle(Overlapped.hEvent);


### PR DESCRIPTION
Hi!
I have noticed a problem in the event of a driver crash of the parsec vdd driver.
The "GetOverlappedResult" function  in VddIoControl blocks indefinitely in this case because the operation does not complete. This causes VddIoControl to never return and as a result the display updater thread cannot be joined.
I found a solution for this problem by using the "GetOverlappedResultEx" function instead with a relatively high timeout of 5 seconds, that can only be triggered in the event of a driver crash.
This ensures that if the operation does not complete in the specified timeout, the function will not block indefinitely and the display updater thread can now be joined in this event.

Edit: Resolved merge conflicts

2nd edit: I scrolled through your code and noticed that you are using GetOverlappedResultEx with a timeout in ParsecVDD.cs already, but it is not used in the parsec-vdd.h file. 