### PR TITLE
Move app signing from build to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: auto-build
+name: Build
 
 on:
   push:
@@ -6,14 +6,13 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
-    permissions:
-      contents: write
+    runs-on: windows-2019
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Prepare envars
@@ -21,12 +20,12 @@ jobs:
           echo "SHORT_SHA=$("${{ github.sha }}" | cut -c1-8)" >> $env:GITHUB_ENV
           echo "APP_VERSION=$((Get-Content -Path "app\Program.cs" | Select-String -Pattern 'AppVersion\s=\s"(.+)"' -AllMatches).Matches.Groups[1].Value)" >> $env:GITHUB_ENV
 
-      - name: Patch project files
-        run: |
-          (Get-Content app\ParsecVDisplay.csproj) -replace "TargetFramework>net472", "TargetFramework>net480" | Out-File app\ParsecVDisplay.csproj
-          (Get-Content app\App.config) -replace "Version=v4.7.2", "Version=v4.8" | Out-File app\App.config
+      # - name: Target .NET 4.8
+      #   run: |
+      #     (Get-Content app\ParsecVDisplay.csproj) -replace "TargetFramework>net472", "TargetFramework>net480" | Out-File app\ParsecVDisplay.csproj
+      #     (Get-Content app\App.config) -replace "Version=v4.7.2", "Version=v4.8" | Out-File app\App.config
 
-      - name: Setup msbuild
+      - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
       - name: Build app
@@ -34,30 +33,13 @@ jobs:
           cd app
           msbuild ParsecVDisplay.csproj /t:Restore
           msbuild ParsecVDisplay.csproj /t:Build /p:Configuration=Release /p:Platform=AnyCPU
+          echo "${{ env.APP_VERSION }}+${{ env.SHORT_SHA }}" > bin\.version
 
       - name: Upload build output
         uses: actions/upload-artifact@v4
-        id: artifact-upload-step
-        with:
-          name: ParsecVDisplay
-          path: app/bin/net480/ParsecVDisplay.exe
-
-      - name: Sign the build
-        uses: signpath/github-action-submit-signing-request@v1
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: b57f6752-7123-475c-9185-6bfea1032f02
-          project-slug: parsec-vdd
-          signing-policy-slug: release-signing
-          artifact-configuration-slug: portable-app
-          github-artifact-id: "${{steps.artifact-upload-step.outputs.artifact-id}}"
-          wait-for-completion: true
-          output-artifact-directory: "bin"
-          parameters: |
-            Version: "${{ github.ref_name }}"
-
-      - name: Upload signed build
-        uses: actions/upload-artifact@v4
         with:
           name: ParsecVDisplay-v${{ env.APP_VERSION }}-${{ env.SHORT_SHA }}
-          path: bin/
+          path: |
+            app/bin/.version
+            app/bin/ParsecVDisplay.exe
+            app/bin/ParsecVDisplay.exe.config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           cd app
           msbuild ParsecVDisplay.csproj /t:Restore
           msbuild ParsecVDisplay.csproj /t:Build /p:Configuration=Release /p:Platform=AnyCPU
-          echo "${{ env.APP_VERSION }}+${{ env.SHORT_SHA }}" > bin\.version
+          echo "${{ env.APP_VERSION }}+${{ env.SHORT_SHA }}" >> bin\.version
 
       - name: Upload build output
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    # branches: [release]
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Get artifact ID
+        uses: actions/github-script@v7
+        id: get-artifact-id
+        with:
+          result-encoding: string
+          script: |
+            const result = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts', {
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ github.event.repository.name }}',
+              run_id: ${{ github.event.workflow_run.id }}
+            });
+            return result.data.artifacts[0].artifact_id;
+
+      - name: Sign the build
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORG_ID }}
+          project-slug: parsec-vdd
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: portable-app
+          github-artifact-id: "${{ steps.get-artifact-id.outputs.result }}"
+          wait-for-completion: true
+          output-artifact-directory: release
+          parameters: |
+            Version: "${{ github.ref_name }}"
+
+      - name: Upload signed output
+        uses: actions/upload-artifact@v4
+        with:
+          name: ParsecVDisplay-v${{ env.APP_VERSION }}-${{ env.SHORT_SHA }}
+          path: |
+            release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [Build]
     types: [completed]
-    # branches: [release]
+    branches: [release]
 
 jobs:
   sign:
@@ -42,6 +42,6 @@ jobs:
       - name: Upload signed output
         uses: actions/upload-artifact@v4
         with:
-          name: ParsecVDisplay-v${{ env.APP_VERSION }}-${{ env.SHORT_SHA }}
+          name: ParsecVDisplay-release
           path: |
             release/

--- a/app/ParsecVDisplay.csproj
+++ b/app/ParsecVDisplay.csproj
@@ -10,6 +10,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Use windows-2019 to reduce workflow startup time
- Default target to .NET 4.7.2